### PR TITLE
add autoprefixer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,8 +16,21 @@ module.exports = function (grunt) {
         cssmin: {
             min: {
                 files: {
-                    'cssco.min.css': 'cssco.css'
+                    'cssco.min.css': 'cssco.min.css'
                 }
+            }
+        },
+        postcss: {
+            options: {
+                processors: [
+                    require('autoprefixer')({
+                        browsers: 'last 2 versions'
+                    })
+                ]
+            },
+            dist: {
+                src: 'cssco.css',
+                dest: 'cssco.min.css'
             }
         }
     });
@@ -25,5 +38,5 @@ module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
 
     grunt.registerTask('lint', ['csslint']);
-    grunt.registerTask('min', ['cssmin']);
+    grunt.registerTask('min', ['postcss', 'cssmin']);
 };

--- a/cssco.css
+++ b/cssco.css
@@ -39,8 +39,7 @@
 }
 
 .cssco.cssco--c1 img {
-    -webkit-filter: grayscale(6%) contrast(130%);
-            filter: grayscale(6%) contrast(130%);
+    filter: grayscale(6%) contrast(130%);
     mix-blend-mode: hard-light;
 }
 
@@ -62,8 +61,7 @@
 }
 
 .cssco.cssco--f2 img {
-    -webkit-filter: contrast(150%);
-            filter: contrast(150%);
+    filter: contrast(150%);
     opacity: 0.85;
 }
 
@@ -80,8 +78,7 @@
 }
 
 .cssco.cssco--g3 img {
-    -webkit-filter: contrast(130%);
-            filter: contrast(130%);
+    filter: contrast(130%);
     mix-blend-mode: hard-light;
 }
 
@@ -103,8 +100,7 @@
 }
 
 .cssco.cssco--p5 img {
-    -webkit-filter: contrast(150%) grayscale(15%);
-            filter: contrast(150%) grayscale(15%);
+    filter: contrast(150%) grayscale(15%);
     opacity: 0.8;
 }
 
@@ -121,8 +117,7 @@
 }
 
 .cssco.cssco--lv3 img {
-    -webkit-filter: grayscale(20%) contrast(130%);
-            filter: grayscale(20%) contrast(130%);
+    filter: grayscale(20%) contrast(130%);
     mix-blend-mode: hard-light;
 }
 
@@ -139,8 +134,7 @@
 }
 
 .cssco.cssco--b5 img {
-    -webkit-filter: grayscale(100%) contrast(180%) brightness(95%);
-            filter: grayscale(100%) contrast(180%) brightness(95%);
+    filter: grayscale(100%) contrast(180%) brightness(95%);
     opacity: 0.9;
 }
 
@@ -162,8 +156,7 @@
 }
 
 .cssco.cssco--a6 img {
-    -webkit-filter: grayscale(30%) contrast(140%) hue-rotate(-5deg);
-            filter: grayscale(30%) contrast(140%) hue-rotate(-5deg);
+    filter: grayscale(30%) contrast(140%) hue-rotate(-5deg);
     mix-blend-mode: hard-light;
 }
 
@@ -186,8 +179,7 @@
 }
 
 .cssco.cssco--m5 img {
-    -webkit-filter: grayscale(40%) contrast(110%);
-            filter: grayscale(40%) contrast(110%);
+    filter: grayscale(40%) contrast(110%);
     mix-blend-mode: hard-light;
 }
 
@@ -210,8 +202,7 @@
 }
 
 .cssco.cssco--m3 img {
-    -webkit-filter: grayscale(30%) contrast(155%);
-            filter: grayscale(30%) contrast(155%);
+    filter: grayscale(30%) contrast(155%);
     mix-blend-mode: hard-light;
     opacity: 0.75;
 }
@@ -235,8 +226,7 @@
 }
 
 .cssco.cssco--hb1 img {
-    -webkit-filter: grayscale(20%) contrast(130%);
-            filter: grayscale(20%) contrast(130%);
+    filter: grayscale(20%) contrast(130%);
     mix-blend-mode: hard-light;
 }
 
@@ -259,8 +249,7 @@
 }
 
 .cssco.cssco--hb2 img {
-    -webkit-filter: grayscale(20%) contrast(130%);
-            filter: grayscale(20%) contrast(130%);
+    filter: grayscale(20%) contrast(130%);
     mix-blend-mode: hard-light;
 }
 
@@ -282,8 +271,7 @@
 }
 
 .cssco.cssco--acg img {
-    -webkit-filter: grayscale(40%) contrast(160%) brightness(85%) hue-rotate(-5deg);
-            filter: grayscale(40%) contrast(160%) brightness(85%) hue-rotate(-5deg);
+    filter: grayscale(40%) contrast(160%) brightness(85%) hue-rotate(-5deg);
     mix-blend-mode: darken;
     opacity: 0.85;
 }
@@ -306,8 +294,7 @@
 }
 
 .cssco.cssco--x1 img {
-    -webkit-filter: grayscale(100%) contrast(190%) brightness(110%);
-            filter: grayscale(100%) contrast(190%) brightness(110%);
+    filter: grayscale(100%) contrast(190%) brightness(110%);
     opacity: 0.75;
 }
 
@@ -330,7 +317,6 @@
 }
 
 .cssco.cssco--t1 img {
-    -webkit-filter: grayscale(20%) contrast(140%);
-            filter: grayscale(20%) contrast(140%);
+    filter: grayscale(20%) contrast(140%);
     mix-blend-mode: hard-light;
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,24 @@
 {
-  "name": "cssco",
-  "version": "1.0.0",
-  "description": "Photographic filters made with CSS, inpsired by VSCO and CSSgram.",
-  "author": "Lauren Waller",
-  "license": "MIT",
-  "repository": {
-      "type": "git",
-      "url": "https://github.com/we-are-next/cssco.git"
-  },
-  "scripts": {
-      "lint": "grunt lint",
-      "minify": "grunt min"
-  },
-  "devDependencies": {
-      "grunt": "^0.4.5",
-      "grunt-contrib-csslint": "^0.5.0",
-      "grunt-contrib-cssmin": "^0.14.0",
-      "load-grunt-tasks": "^3.4.0",
-      "time-grunt": "^1.3.0"
-  }
+    "name": "cssco",
+    "version": "1.0.0",
+    "description": "Photographic filters made with CSS, inpsired by VSCO and CSSgram.",
+    "author": "Lauren Waller",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/we-are-next/cssco.git"
+    },
+    "scripts": {
+        "lint": "grunt lint",
+        "minify": "grunt min"
+    },
+    "devDependencies": {
+        "autoprefixer": "^6.3.3",
+        "grunt": "^0.4.5",
+        "grunt-contrib-csslint": "^0.5.0",
+        "grunt-contrib-cssmin": "^0.14.0",
+        "grunt-postcss": "^0.7.2",
+        "load-grunt-tasks": "^3.4.0",
+        "time-grunt": "^1.3.0"
+    }
 }


### PR DESCRIPTION
Use Autoprefixer to add vendor prefixes:
- remove vendor prefixes from source file
- add Autoprefixer
- update Grunt tasks
